### PR TITLE
Updates to accommodate more states, transition away from time-series models

### DIFF
--- a/EHM-data-sandbox.ipynb
+++ b/EHM-data-sandbox.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "adff2d6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src import Processor, Reader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "33f27872",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the US Census regions from here: https://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf\n",
+    "south_atlantic_states = [\n",
+    "    10   # Delaware\n",
+    "    , 11 # DC\n",
+    "    , 12 # Florida\n",
+    "    , 13 # Georgia\n",
+    "    , 24 # Maryland\n",
+    "    , 37 # North Carolina\n",
+    "    , 45 # South Carolina\n",
+    "    , 51 # Virginia\n",
+    "    , 54 # West Virginia\n",
+    "]\n",
+    "state_filter = south_atlantic_states"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "20b7412b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate preprocessor\n",
+    "preprocessor = Processor.PreProcessor(state_filter=state_filter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9582f31e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:28: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  merged_df = self.init_cdc_data().merge(self.init_vaccinations_data(), how='left', on=['date', 'FIPS'])\n",
+      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:28: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  merged_df = self.init_cdc_data().merge(self.init_vaccinations_data(), how='left', on=['date', 'FIPS'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load processed data\n",
+    "preprocessor.load_processed_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c3d1f984",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Put data into a df to work with\n",
+    "df = preprocessor.get_current_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8fc1c7fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>FIPS_10001</th>\n",
+       "      <th>FIPS_10003</th>\n",
+       "      <th>FIPS_10005</th>\n",
+       "      <th>FIPS_11001</th>\n",
+       "      <th>FIPS_12001</th>\n",
+       "      <th>FIPS_12003</th>\n",
+       "      <th>FIPS_12005</th>\n",
+       "      <th>FIPS_12007</th>\n",
+       "      <th>FIPS_12009</th>\n",
+       "      <th>FIPS_12011</th>\n",
+       "      <th>...</th>\n",
+       "      <th>restuarants_limited_open_outdoor_only_Yes</th>\n",
+       "      <th>restuarants_limited_open_outdoor_only_nan</th>\n",
+       "      <th>restuarants_limited_open_general_indoor_Yes</th>\n",
+       "      <th>restuarants_limited_open_general_indoor_nan</th>\n",
+       "      <th>Series_Complete_Pop_Pct</th>\n",
+       "      <th>Administered_Dose1_Pop_Pct</th>\n",
+       "      <th>is_metro</th>\n",
+       "      <th>Series_Complete_Pop_Pct_UR_Equity</th>\n",
+       "      <th>cases</th>\n",
+       "      <th>deaths</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>230.0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>255.0</td>\n",
+       "      <td>4.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>281.0</td>\n",
+       "      <td>4.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>288.0</td>\n",
+       "      <td>6.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>329.0</td>\n",
+       "      <td>7.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 686 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  FIPS_10001 FIPS_10003 FIPS_10005 FIPS_11001 FIPS_12001 FIPS_12003  \\\n",
+       "0        1.0        0.0        0.0        0.0        0.0        0.0   \n",
+       "1        1.0        0.0        0.0        0.0        0.0        0.0   \n",
+       "2        1.0        0.0        0.0        0.0        0.0        0.0   \n",
+       "3        1.0        0.0        0.0        0.0        0.0        0.0   \n",
+       "4        1.0        0.0        0.0        0.0        0.0        0.0   \n",
+       "\n",
+       "  FIPS_12005 FIPS_12007 FIPS_12009 FIPS_12011  ...  \\\n",
+       "0        0.0        0.0        0.0        0.0  ...   \n",
+       "1        0.0        0.0        0.0        0.0  ...   \n",
+       "2        0.0        0.0        0.0        0.0  ...   \n",
+       "3        0.0        0.0        0.0        0.0  ...   \n",
+       "4        0.0        0.0        0.0        0.0  ...   \n",
+       "\n",
+       "  restuarants_limited_open_outdoor_only_Yes  \\\n",
+       "0                                       0.0   \n",
+       "1                                       0.0   \n",
+       "2                                       0.0   \n",
+       "3                                       0.0   \n",
+       "4                                       0.0   \n",
+       "\n",
+       "  restuarants_limited_open_outdoor_only_nan  \\\n",
+       "0                                       1.0   \n",
+       "1                                       1.0   \n",
+       "2                                       1.0   \n",
+       "3                                       1.0   \n",
+       "4                                       1.0   \n",
+       "\n",
+       "  restuarants_limited_open_general_indoor_Yes  \\\n",
+       "0                                         0.0   \n",
+       "1                                         0.0   \n",
+       "2                                         0.0   \n",
+       "3                                         0.0   \n",
+       "4                                         0.0   \n",
+       "\n",
+       "  restuarants_limited_open_general_indoor_nan Series_Complete_Pop_Pct  \\\n",
+       "0                                         1.0                     NaN   \n",
+       "1                                         1.0                     NaN   \n",
+       "2                                         1.0                     NaN   \n",
+       "3                                         1.0                     NaN   \n",
+       "4                                         1.0                     NaN   \n",
+       "\n",
+       "  Administered_Dose1_Pop_Pct is_metro Series_Complete_Pop_Pct_UR_Equity  \\\n",
+       "0                        NaN      NaN                               NaN   \n",
+       "1                        NaN      NaN                               NaN   \n",
+       "2                        NaN      NaN                               NaN   \n",
+       "3                        NaN      NaN                               NaN   \n",
+       "4                        NaN      NaN                               NaN   \n",
+       "\n",
+       "   cases deaths  \n",
+       "0  230.0    3.0  \n",
+       "1  255.0    4.0  \n",
+       "2  281.0    4.0  \n",
+       "3  288.0    6.0  \n",
+       "4  329.0    7.0  \n",
+       "\n",
+       "[5 rows x 686 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0194b856",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you'd like to store the preprocessed df locally, you can export it to csv just like any other df\n",
+    "# df.to_csv('data/transformed_data/full_df.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "80f7223e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(289884, 686)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ac3b197",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "742e51f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/elizabethmartens/opt/anaconda3/lib/python3.8/site-packages/IPython/core/interactiveshell.py:3437: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  exec(code_obj, self.user_global_ns, self.user_ns)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Gathering Bans data\n",
+    "# gb_df = Reader.GatheringBansReader().read_and_process_data(state_filter=state_filter)\n",
+    "# Mask Mandates data\n",
+    "# mm_df = Reader.MaskMandatesReader().read_and_process_data(state_filter=state_filter)\n",
+    "# Stay at home order data\n",
+    "# stay_at_home_df = Reader.StayAtHomeOrdersReader().read_and_process_data(state_filter=state_filter)\n",
+    "# Bar closure data\n",
+    "# bars_df = Reader.BarClosuresReader().read_and_process_data(state_filter=state_filter)\n",
+    "# Restaurant closure data\n",
+    "# restaurants_df = Reader.RestaurantClosuresReader().read_and_process_data(state_filter=state_filter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b694c2ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/EHM-data-sandbox.ipynb
+++ b/EHM-data-sandbox.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "adff2d6e",
+   "id": "ed224a17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "33f27872",
+   "id": "7b5c5254",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,8 +34,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "20b7412b",
+   "execution_count": 3,
+   "id": "b6d8b615",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,30 +45,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "9582f31e",
+   "execution_count": 4,
+   "id": "ba89cf93",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:28: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:36: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  merged_df = self.init_cdc_data().merge(self.init_vaccinations_data(), how='left', on=['date', 'FIPS'])\n",
-      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:28: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/Users/elizabethmartens/cs5644/project/projectGitRepo/src/Processor.py:36: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  merged_df = self.init_cdc_data().merge(self.init_vaccinations_data(), how='left', on=['date', 'FIPS'])\n"
      ]
     }
    ],
    "source": [
-    "# Load processed data\n",
-    "preprocessor.load_processed_data()"
+    "# Load processed data with FIPS codes turned into boolean columns\n",
+    "preprocessor.load_processed_data()\n",
+    "\n",
+    "# To load the data WITHOUT FIPs codes, Months, and State turned into boolean columns, use this:\n",
+    "# preprocessor.load_processed_data_without_fips_as_columns()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "c3d1f984",
+   "execution_count": null,
+   "id": "04f54d35",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9976e6a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,8 +89,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "8fc1c7fd",
+   "execution_count": 6,
+   "id": "a04a4254",
    "metadata": {},
    "outputs": [
     {
@@ -114,7 +125,6 @@
        "      <th>FIPS_12009</th>\n",
        "      <th>FIPS_12011</th>\n",
        "      <th>...</th>\n",
-       "      <th>restuarants_limited_open_outdoor_only_Yes</th>\n",
        "      <th>restuarants_limited_open_outdoor_only_nan</th>\n",
        "      <th>restuarants_limited_open_general_indoor_Yes</th>\n",
        "      <th>restuarants_limited_open_general_indoor_nan</th>\n",
@@ -124,6 +134,7 @@
        "      <th>Series_Complete_Pop_Pct_UR_Equity</th>\n",
        "      <th>cases</th>\n",
        "      <th>deaths</th>\n",
+       "      <th>days_from_start</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -140,16 +151,16 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>230.0</td>\n",
        "      <td>3.0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -164,16 +175,16 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>255.0</td>\n",
        "      <td>4.0</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -188,16 +199,16 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>281.0</td>\n",
        "      <td>4.0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -212,16 +223,16 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>288.0</td>\n",
        "      <td>6.0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -236,20 +247,20 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>329.0</td>\n",
        "      <td>7.0</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 686 columns</p>\n",
+       "<p>5 rows × 699 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -267,13 +278,6 @@
        "3        0.0        0.0        0.0        0.0  ...   \n",
        "4        0.0        0.0        0.0        0.0  ...   \n",
        "\n",
-       "  restuarants_limited_open_outdoor_only_Yes  \\\n",
-       "0                                       0.0   \n",
-       "1                                       0.0   \n",
-       "2                                       0.0   \n",
-       "3                                       0.0   \n",
-       "4                                       0.0   \n",
-       "\n",
        "  restuarants_limited_open_outdoor_only_nan  \\\n",
        "0                                       1.0   \n",
        "1                                       1.0   \n",
@@ -289,30 +293,30 @@
        "4                                         0.0   \n",
        "\n",
        "  restuarants_limited_open_general_indoor_nan Series_Complete_Pop_Pct  \\\n",
-       "0                                         1.0                     NaN   \n",
-       "1                                         1.0                     NaN   \n",
-       "2                                         1.0                     NaN   \n",
-       "3                                         1.0                     NaN   \n",
-       "4                                         1.0                     NaN   \n",
+       "0                                         1.0                     0.0   \n",
+       "1                                         1.0                     0.0   \n",
+       "2                                         1.0                     0.0   \n",
+       "3                                         1.0                     0.0   \n",
+       "4                                         1.0                     0.0   \n",
        "\n",
        "  Administered_Dose1_Pop_Pct is_metro Series_Complete_Pop_Pct_UR_Equity  \\\n",
-       "0                        NaN      NaN                               NaN   \n",
-       "1                        NaN      NaN                               NaN   \n",
-       "2                        NaN      NaN                               NaN   \n",
-       "3                        NaN      NaN                               NaN   \n",
-       "4                        NaN      NaN                               NaN   \n",
+       "0                        0.0      1.0                               0.0   \n",
+       "1                        0.0      1.0                               0.0   \n",
+       "2                        0.0      1.0                               0.0   \n",
+       "3                        0.0      1.0                               0.0   \n",
+       "4                        0.0      1.0                               0.0   \n",
        "\n",
-       "   cases deaths  \n",
-       "0  230.0    3.0  \n",
-       "1  255.0    4.0  \n",
-       "2  281.0    4.0  \n",
-       "3  288.0    6.0  \n",
-       "4  329.0    7.0  \n",
+       "   cases deaths days_from_start  \n",
+       "0  230.0    3.0               0  \n",
+       "1  255.0    4.0               1  \n",
+       "2  281.0    4.0               2  \n",
+       "3  288.0    6.0               3  \n",
+       "4  329.0    7.0               4  \n",
        "\n",
-       "[5 rows x 686 columns]"
+       "[5 rows x 699 columns]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,8 +327,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "0194b856",
+   "execution_count": 7,
+   "id": "6a8ce833",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,17 +338,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "80f7223e",
+   "execution_count": 7,
+   "id": "6cf0c1ad",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(289884, 686)"
+       "(289884, 699)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,27 +360,178 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ac3b197",
+   "id": "cc53d105",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "742e51f5",
+   "execution_count": null,
+   "id": "dbad8b79",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f4a2b37b",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "data": {
+      "text/plain": [
+       "(289884, 91)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "344e7f97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/elizabethmartens/opt/anaconda3/lib/python3.8/site-packages/IPython/core/interactiveshell.py:3437: DtypeWarning: Columns (15) have mixed types.Specify dtype option on import or set low_memory=False.\n",
-      "  exec(code_obj, self.user_global_ns, self.user_ns)\n"
+      "month_April\n",
+      "month_August\n",
+      "month_December\n",
+      "month_February\n",
+      "month_January\n",
+      "month_July\n",
+      "month_June\n",
+      "month_March\n",
+      "month_May\n",
+      "month_November\n",
+      "month_October\n",
+      "month_September\n",
+      "STATE_10\n",
+      "STATE_11\n",
+      "STATE_12\n",
+      "STATE_13\n",
+      "STATE_24\n",
+      "STATE_37\n",
+      "STATE_45\n",
+      "STATE_51\n",
+      "STATE_54\n",
+      "gathering_ban_order_group_ban_gatherings_of_any_size\n",
+      "gathering_ban_order_group_ban_over_101_or_more_ppl\n",
+      "gathering_ban_order_group_ban_over_11_to_25_ppl\n",
+      "gathering_ban_order_group_ban_over_1_to_10_ppl\n",
+      "gathering_ban_order_group_ban_over_26_to_50_ppl\n",
+      "gathering_ban_order_group_ban_over_51_to_100_ppl\n",
+      "gathering_ban_order_group_no_order_found\n",
+      "gathering_ban_express_preemption_Expressly Preempts\n",
+      "gathering_ban_express_preemption_Expressly Preempts Less Restrictive Measures\n",
+      "gathering_ban_express_preemption_Unknown\n",
+      "gathering_ban_express_preemption_nan\n",
+      "gathering_ban_source_of_action_nan\n",
+      "gathering_ban_source_of_action_news\n",
+      "gathering_ban_source_of_action_official\n",
+      "gathering_ban_source_of_action_official_announcement\n",
+      "gathering_ban_source_of_action_press_release\n",
+      "date\n",
+      "Stay_at_Home_Order_Recommendation_advisory\n",
+      "Stay_at_Home_Order_Recommendation_mandatory_for_all_individuals\n",
+      "Stay_at_Home_Order_Recommendation_mandatory_only_for_all_individuals_in_certain_areas_of_the_jurisdiction\n",
+      "Stay_at_Home_Order_Recommendation_mandatory_only_for_at_risk_individuals_in_the_jurisdiction\n",
+      "Stay_at_Home_Order_Recommendation_nan\n",
+      "Stay_at_Home_Order_Recommendation_no_order_for_individuals_to_stay_home\n",
+      "stay_at_home_express_preemption_expressly_does_not_preempt\n",
+      "stay_at_home_express_preemption_expressly_preempts\n",
+      "stay_at_home_express_preemption_local_orders_moot_due_to_statewide_mandate\n",
+      "stay_at_home_express_preemption_nan\n",
+      "stay_at_home_express_preemption_unknown\n",
+      "stay_at_home_source_of_action_Official\n",
+      "stay_at_home_source_of_action_nan\n",
+      "stay_at_home_order_code\n",
+      "Face_Masks_Required_in_Public_No\n",
+      "Face_Masks_Required_in_Public_Yes\n",
+      "Face_Masks_Required_in_Public_nan\n",
+      "mask_mandate_source_of_action_Official\n",
+      "mask_mandate_source_of_action_nan\n",
+      "mask_mandate_order_code\n",
+      "bars_action_authorized_to_fully_reopen\n",
+      "bars_action_closed\n",
+      "bars_action_curbside_or_carryout_or_delivery_only\n",
+      "bars_action_nan\n",
+      "bars_action_open_w_social_distancing_or_reduced_seating_or_enhanced_sanitation\n",
+      "bars_source_of_action_Official\n",
+      "bars_source_of_action_nan\n",
+      "bars_percent_capacity_outdoor_30_percent\n",
+      "bars_percent_capacity_outdoor_50_percent\n",
+      "bars_percent_capacity_outdoor_nan\n",
+      "bars_percent_capacity_outdoor_not_specified\n",
+      "bars_percent_capacity_indoor_100_percent\n",
+      "bars_percent_capacity_indoor_30_percent\n",
+      "bars_percent_capacity_indoor_35_percent\n",
+      "bars_percent_capacity_indoor_50_percent\n",
+      "bars_percent_capacity_indoor_60_percent\n",
+      "bars_percent_capacity_indoor_75_percent\n",
+      "bars_percent_capacity_indoor_nan\n",
+      "bars_percent_capacity_indoor_not_specified\n",
+      "bars_limited_open_outdoor_only_Yes\n",
+      "bars_limited_open_outdoor_only_nan\n",
+      "bars_limited_open_general_indoor_Yes\n",
+      "bars_limited_open_general_indoor_nan\n",
+      "restuarants_action_authorized_to_fully_reopen\n",
+      "restuarants_action_curbside_or_carryout_or_delivery_only\n",
+      "restuarants_action_nan\n",
+      "restuarants_action_open_w_social_distancing_or_reduced_seating_or_enhanced_sanitation\n",
+      "restuarants_source_of_action_Official\n",
+      "restuarants_source_of_action_nan\n",
+      "restuarants_percent_capacity_outdoor_100_percent\n",
+      "restuarants_percent_capacity_outdoor_30_percent\n",
+      "restuarants_percent_capacity_outdoor_50_percent\n",
+      "restuarants_percent_capacity_outdoor_nan\n",
+      "restuarants_percent_capacity_outdoor_not_specified\n",
+      "restuarants_percent_capacity_indoor_100_percent\n",
+      "restuarants_percent_capacity_indoor_25_percent\n",
+      "restuarants_percent_capacity_indoor_30_percent\n",
+      "restuarants_percent_capacity_indoor_50_percent\n",
+      "restuarants_percent_capacity_indoor_60_percent\n",
+      "restuarants_percent_capacity_indoor_75_percent\n",
+      "restuarants_percent_capacity_indoor_nan\n",
+      "restuarants_percent_capacity_indoor_not_specified\n",
+      "restuarants_limited_open_outdoor_only_Yes\n",
+      "restuarants_limited_open_outdoor_only_nan\n",
+      "restuarants_limited_open_general_indoor_Yes\n",
+      "restuarants_limited_open_general_indoor_nan\n",
+      "Series_Complete_Pop_Pct\n",
+      "Administered_Dose1_Pop_Pct\n",
+      "is_metro\n",
+      "Series_Complete_Pop_Pct_UR_Equity\n",
+      "cases\n",
+      "deaths\n",
+      "days_from_start\n"
      ]
     }
    ],
    "source": [
+    "for x in df.columns:\n",
+    "    if 'FIPS' not in x:\n",
+    "        print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b80fcab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checking specific data pre-merge: \n",
     "# Gathering Bans data\n",
     "# gb_df = Reader.GatheringBansReader().read_and_process_data(state_filter=state_filter)\n",
     "# Mask Mandates data\n",
@@ -392,10 +547,117 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b694c2ad",
+   "id": "51aedaf6",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Messing with date spine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "8926b131",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = df['date'].astype('datetime64[ns]').apply(lambda x: x.strftime('%B'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "7afb2819",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['date'] = df['date'].astype('datetime64[ns]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c7f3b930",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Timestamp('2021-08-15 00:00:00')"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['date'].max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "ccc77a8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Timestamp('2020-04-10 00:00:00')"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "min_date = df['date'].min()\n",
+    "min_date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "6fe85df5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = df['date'].apply(lambda x: (x - min_date).days)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b35780b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0           0\n",
+       "1           1\n",
+       "2           2\n",
+       "3           3\n",
+       "4           4\n",
+       "         ... \n",
+       "289879    488\n",
+       "289880    489\n",
+       "289881    490\n",
+       "289882    491\n",
+       "289883    492\n",
+       "Name: date, Length: 289884, dtype: int64"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test"
+   ]
   }
  ],
  "metadata": {

--- a/src/Reader.py
+++ b/src/Reader.py
@@ -492,7 +492,7 @@ class VaccinationsReader(Reader):
                 , 'FIPS'
                 , 'Series_Complete_Pop_Pct'
                 , 'Administered_Dose1_Pop_Pct' # Are these also counted in the above
-                , 'Metro_status' # Will need to convert this into a boolean fields
+                , 'Metro_status' # Will need to convert this into a boolean fields 
                 , 'Series_Complete_Pop_Pct_UR_Equity' # Not sure how this is working, it's either null or a value 1-8
                 ]
             )

--- a/src/Reader.py
+++ b/src/Reader.py
@@ -98,7 +98,8 @@ class GatheringBansReader(Reader):
                             )
         # Renaming gathering_ban_order_group fields to be more amenable to transformation:
         order_group_dict = {
-            'Ban of gatherings over 1-10 people': 'ban_over_1_to_10_ppl'
+            'Bans gatherings of any size' : 'ban_gatherings_of_any_size'
+            , 'Ban of gatherings over 1-10 people': 'ban_over_1_to_10_ppl'
             , 'Ban of gatherings over 11-25 people' : 'ban_over_11_to_25_ppl'
             , 'Ban of gatherings over 26-50 people': 'ban_over_26_to_50_ppl'
             , 'Ban of gatherings over 51-100 people': 'ban_over_51_to_100_ppl'
@@ -108,8 +109,12 @@ class GatheringBansReader(Reader):
         gathering_bans_df['gathering_ban_order_group'] = gathering_bans_df['gathering_ban_order_group'].apply(lambda x: order_group_dict[x]) 
         # Renaming gathering_ban_source_of_action fields to be more amenable to transformation:
         source_of_action_dict = {
-            'Official': 'official'
+            'News' : 'news'
+            , 'News Media' : 'news'
+            , 'Offcial': 'official' # Typo in source data
+            , 'Official': 'official'
             , 'Official Announcement' : 'official_announcement'
+            , 'Press Release' : 'press_release'
         }
         gathering_bans_df['gathering_ban_source_of_action'] = gathering_bans_df['gathering_ban_source_of_action'].apply(lambda x: x if pd.isna(x) else source_of_action_dict[x]) 
         # Transform to categorical variables as needed.
@@ -225,8 +230,10 @@ class StayAtHomeOrdersReader(Reader):
                             )
         # Renaming stay_at_home_order_code fields to be more amenable to transformation:
         order_group_dict = {
-            'Mandatory for all individuals': 'mandatory_for_all_individuals'
+            'Advisory/Recommendation' : 'advisory'
+            , 'Mandatory for all individuals': 'mandatory_for_all_individuals'
             , 'Mandatory only for all individuals in certain areas of the jurisdiction' : 'mandatory_only_for_all_individuals_in_certain_areas_of_the_jurisdiction'
+            , 'Mandatory only for at-risk individuals in the jurisdiction' : 'mandatory_only_for_at_risk_individuals_in_the_jurisdiction'
             , 'No order for individuals to stay home': 'no_order_for_individuals_to_stay_home'
         }
         stay_at_home_df['Stay_at_Home_Order_Recommendation'] = stay_at_home_df['Stay_at_Home_Order_Recommendation'].apply(lambda x: x if pd.isna(x) else order_group_dict[x]) 
@@ -236,6 +243,7 @@ class StayAtHomeOrdersReader(Reader):
             , 'Unknown' :'unknown'
             , 'Local orders moot due to statewide mandate': 'local_orders_moot_due_to_statewide_mandate'
             , 'Expressly Does Not Preempt': 'expressly_does_not_preempt'
+            , 'Expressly Preempts' : 'expressly_preempts'
         }
         stay_at_home_df['stay_at_home_express_preemption'] = stay_at_home_df['stay_at_home_express_preemption'].apply(lambda x: x if pd.isna(x) else express_preemption_dict[x]) 
         # Transform categorical variables
@@ -309,8 +317,11 @@ class BarClosuresReader(Reader):
         bars_df['bars_action'] = bars_df['bars_action'].apply(lambda x: x if pd.isna(x) else action_dict[x]) 
         # Renaming percent_capacity fields to be more amenable to transformation:
         pct_capacity_dict = {
-            'Not specified': 'not_specified'
+            'Not specified': 'not_specified' # TODO consider changing this to a numberical variable
+            , '30%' : '30_percent'
+            , '35%' : '35_percent'
             , '50%' : '50_percent'
+            , '60%' : '60_percent'
             , '75%' : '75_percent'
             , '100%' : '100_percent'
         }
@@ -388,9 +399,12 @@ class RestaurantClosuresReader(Reader):
 
         # Renaming percent_capacity fields to be more amenable to transformation:
         pct_capacity_dict = {
-            'Not specified': 'not_specified'
+            'Not specified': 'not_specified' # TODO consider changing this to a numberical variable
             , '25%' : '25_percent'
+            , '30%' : '30_percent'
+            , '35%' : '35_percent'
             , '50%' : '50_percent'
+            , '60%' : '60_percent'
             , '75%' : '75_percent'
             , '100%' : '100_percent'
         }


### PR DESCRIPTION
Updates:
- Adds a notebook with demo code for bringing in the data
- Adds the ability to bring in the data without the FIPS codes, States, and Months pivoted.
    - This is done in a really hacky way and the data reloads every time, so left a todo to redo that if it's really bugging us. For now, we can save a copy of the data locally if we really want to. 
- Adds a `days_from_start` column which is a simple datediff from the date of the row to the start of the data (this can be used to replace the `date` column for modeling, since we will not be using timeseries techniques anymore
- Adds a `month` column 
    - It may be worth changing this to a 'season' column since we only have a year and a half-ish of data